### PR TITLE
Add custom listeners by extending toml-parser to get the manifest POJO

### DIFF
--- a/cli/ballerina-packerina/pom.xml
+++ b/cli/ballerina-packerina/pom.xml
@@ -46,6 +46,10 @@
             <artifactId>ballerina-launcher</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.ballerinalang</groupId>
+            <artifactId>toml-parser</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
         </dependency>

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/Central.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/Central.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.packerina.toml.model;
+
+/**
+ * Defines the properties used in central.
+ *
+ * @since 0.964
+ */
+public class Central {
+    private String accessToken;
+
+    /**
+     * Get the access token.
+     *
+     * @return access token
+     */
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    /**
+     * Sets the value of the access token.
+     *
+     * @param accessToken access token
+     */
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/Dependency.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/Dependency.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.packerina.toml.model;
+
+/**
+ * Defines dependency object fields. The same object will be used to define patches.
+ *
+ * @since 0.964
+ */
+public class Dependency {
+    private String packageName;
+    private String version;
+    private String location;
+
+    /**
+     * Get the package name.
+     *
+     * @return package name
+     */
+    public String getPackageName() {
+        return packageName;
+    }
+
+    /**
+     * Set the package name.
+     *
+     * @param packageName name of the dependency
+     */
+    public void setPackageName(String packageName) {
+        this.packageName = packageName;
+    }
+
+    /**
+     * Get version of the dependency.
+     *
+     * @return version of the dependency
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * Set the version of the dependency.
+     *
+     * @param version version of the dependency
+     */
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    /**
+     * Get the path/location of the dependency.
+     *
+     * @return location of the dependency
+     */
+    public String getLocation() {
+        return location;
+    }
+
+    /**
+     * Set the path/location of the dependency.
+     *
+     * @param location location of the dependency
+     */
+    public void setLocation(String location) {
+        this.location = location;
+    }
+}

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/Manifest.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/Manifest.java
@@ -1,0 +1,270 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.packerina.toml.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Defines the manifest object which is created using the toml file configs.
+ *
+ * @since 0.964
+ */
+public class Manifest {
+    private String name;
+    private String version;
+    private List<String> authors;
+    private List<String> keywords;
+    private String documentationURL;
+    private String homepageURL;
+    private String repositoryURL;
+    private String description;
+    private String readmeFilePath;
+    private String license;
+    private List<Dependency> dependencies = new ArrayList<>();
+    private List<Dependency> patches = new ArrayList<>();
+
+    /**
+     * Get the patches list.
+     *
+     * @return patches list
+     */
+    public List<Dependency> getPatches() {
+        return patches;
+    }
+
+    /**
+     * Add a patch to the patches list.
+     *
+     * @param dependency dependency object
+     */
+    public void addPatches(Dependency dependency) {
+        this.patches.add(dependency);
+        patches = removeDuplicates(patches);
+    }
+
+    /**
+     * Get the dependencies list.
+     *
+     * @return dependencies list
+     */
+    public List<Dependency> getDependencies() {
+        return dependencies;
+    }
+
+    /**
+     * Add a dependency to the dependencies list.
+     *
+     * @param dependency dependency object
+     */
+    public void addDependency(Dependency dependency) {
+        this.dependencies.add(dependency);
+        dependencies = removeDuplicates(dependencies);
+    }
+
+    /**
+     * Get keywords.
+     *
+     * @return list of keywords
+     */
+    public List<String> getKeywords() {
+        return keywords;
+    }
+
+    /**
+     * Set keywords list.
+     *
+     * @param keywords keyword list
+     */
+    public void setKeywords(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    /**
+     * Get file path of the readme file.
+     *
+     * @return file path of the readme file
+     */
+    public String getReadmeFilePath() {
+        return readmeFilePath;
+    }
+
+    /**
+     * Set file path of the readme file.
+     *
+     * @param readmeFilePath file path of the readme file
+     */
+    public void setReadmeFilePath(String readmeFilePath) {
+        this.readmeFilePath = readmeFilePath;
+    }
+
+    /**
+     * Get documentation URL.
+     *
+     * @return documentation URL
+     */
+    public String getDocumentationURL() {
+        return documentationURL;
+    }
+
+    /**
+     * Set documentation URL.
+     *
+     * @param documentationURL documentation URL
+     */
+    public void setDocumentationURL(String documentationURL) {
+        this.documentationURL = documentationURL;
+    }
+
+    /**
+     * Get homepage URL.
+     *
+     * @return homepage URL
+     */
+    public String getHomepageURL() {
+        return homepageURL;
+    }
+
+    /**
+     * Set homepage URL.
+     *
+     * @param homepageURL homepage URL
+     */
+    public void setHomepageURL(String homepageURL) {
+        this.homepageURL = homepageURL;
+    }
+
+    /**
+     * Get repository URL.
+     *
+     * @return repository URL
+     */
+    public String getRepositoryURL() {
+        return repositoryURL;
+    }
+
+    /**
+     * Set the repository URL.
+     *
+     * @param repositoryURL repository URL
+     */
+    public void setRepositoryURL(String repositoryURL) {
+        this.repositoryURL = repositoryURL;
+    }
+
+    /**
+     * Get description.
+     *
+     * @return description
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Set the description.
+     *
+     * @param description description about the package
+     */
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+     * Get authors of the toml file.
+     *
+     * @return authors
+     */
+    public List<String> getAuthors() {
+        return authors;
+    }
+
+    /**
+     * Set authors of the toml file.
+     *
+     * @param authors list of authors
+     */
+    public void setAuthors(List<String> authors) {
+        this.authors = authors;
+    }
+
+    /**
+     * Get the package name.
+     *
+     * @return package name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Set the package name.
+     *
+     * @param name package name
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Get the version.
+     *
+     * @return version
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * Set the version
+     *
+     * @param version version of the package.
+     */
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    /**
+     * Get the license.
+     *
+     * @return license
+     */
+    public String getLicense() {
+        return license;
+    }
+
+    /**
+     * Set the license.
+     *
+     * @param license license
+     */
+    public void setLicense(String license) {
+        this.license = license;
+    }
+
+    /**
+     * Remove duplicates from dependencies and patches list.
+     *
+     * @param list list of elements
+     * @return dependencies or patches list without duplicates
+     */
+    private List<Dependency> removeDuplicates(List<Dependency> list) {
+        return list.stream().distinct().collect(Collectors.toList());
+    }
+}

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/Proxy.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/Proxy.java
@@ -1,0 +1,102 @@
+/*
+*  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.ballerinalang.packerina.toml.model;
+
+/**
+ * Describes the proxy object.
+ *
+ * @since 0.964
+ */
+public class Proxy {
+    private String host;
+    private String port;
+    private String userName;
+    private String password;
+
+    /**
+     * Get host name.
+     *
+     * @return host
+     */
+    public String getHost() {
+        return host;
+    }
+
+    /**
+     * Set host name.
+     *
+     * @param host host name
+     */
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    /**
+     * Get port.
+     *
+     * @return port proxy server
+     */
+    public String getPort() {
+        return port;
+    }
+
+    /**
+     * Set the port of the proxy server.
+     *
+     * @param port port of the proxy
+     */
+    public void setPort(String port) {
+        this.port = port;
+    }
+
+    /**
+     * Get the username of the proxy server.
+     *
+     * @return username username of the proxy server
+     */
+    public String getUserName() {
+        return userName;
+    }
+
+    /**
+     * Set the username of the proxy server.
+     *
+     * @param userName username of the proxy server
+     */
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    /**
+     * Ge the password of the proxy server.
+     *
+     * @return password of the proxy server
+     */
+    public String getPassword() {
+        return password;
+    }
+
+    /**
+     * Set the password for the proxy server.
+     *
+     * @param password password of the proxy
+     */
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/Settings.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/Settings.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.packerina.toml.model;
+
+/**
+ * Defines the settings object which is created using the toml file configs.
+ *
+ * @since 0.964
+ */
+public class Settings {
+    private Proxy proxy;
+    private Central central;
+
+    /**
+     * Get the proxy configuration object.
+     *
+     * @return proxy config object
+     */
+    public Proxy getProxy() {
+        return proxy;
+    }
+
+    /**
+     * Set the proxy configuration object.
+     *
+     * @param proxy proxy config object
+     */
+    public void setProxy(Proxy proxy) {
+        this.proxy = proxy;
+    }
+
+    /**
+     * Get the central configuration object.
+     *
+     * @return central config object
+     */
+    public Central getCentral() {
+        return central;
+    }
+
+    /**
+     * Set the central config object.
+     *
+     * @param central central config object
+     */
+    public void setCentral(Central central) {
+        this.central = central;
+    }
+
+
+}

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/fields/CentralField.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/fields/CentralField.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.packerina.toml.model.fields;
+
+import org.ballerinalang.packerina.toml.model.Central;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+/**
+ * Central object fields.
+ *
+ * @since 0.964
+ */
+public enum CentralField {
+    ACCESSTOKEN(Central::setAccessToken);
+
+    private static final Map<String, CentralField> LOOKUP = new HashMap<>();
+
+    static {
+        for (CentralField centralField : CentralField.values()) {
+
+            LOOKUP.put(centralField.name().toLowerCase(Locale.ENGLISH), centralField);
+        }
+    }
+
+    private final BiConsumer<Central, String> stringSetter;
+
+    /**
+     * Constructor which sets the string value.
+     *
+     * @param stringSetter string value to be set
+     */
+    CentralField(BiConsumer<Central, String> stringSetter) {
+        this.stringSetter = stringSetter;
+    }
+
+    /**
+     * Like as valueOf method, but input should be all lower case.
+     *
+     * @param fieldKey Lower case string value of filed to find.
+     * @return Matching enum.
+     */
+    public static CentralField valueOfLowerCase(String fieldKey) {
+        return LOOKUP.get(fieldKey);
+    }
+
+    /**
+     * Set values to the central object.
+     *
+     * @param central object
+     * @param value   value to be set
+     */
+    public void setValueTo(Central central, String value) {
+        stringSetter.accept(central, value);
+    }
+}

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/fields/DependencyField.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/fields/DependencyField.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.packerina.toml.model.fields;
+
+import org.ballerinalang.packerina.toml.model.Dependency;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+/**
+ * Dependency object fields.
+ *
+ * @since 0.964
+ */
+public enum DependencyField {
+    NAME(Dependency::setPackageName),
+    VERSION(Dependency::setVersion),
+    LOCATION(Dependency::setLocation);
+
+    private static final Map<String, DependencyField> LOOKUP = new HashMap<>();
+
+    static {
+        for (DependencyField dependencyField : DependencyField.values()) {
+            LOOKUP.put(dependencyField.name().toLowerCase(Locale.ENGLISH), dependencyField);
+        }
+    }
+
+    private final BiConsumer<Dependency, String> stringSetter;
+
+    /**
+     * Constructor which sets the string value.
+     *
+     * @param stringSetter string value to be set
+     */
+    DependencyField(BiConsumer<Dependency, String> stringSetter) {
+        this.stringSetter = stringSetter;
+    }
+
+    /**
+     * Like as valueOf method, but input should be all lower case.
+     *
+     * @param fieldKey Lower case string value of filed to find.
+     * @return Matching enum.
+     */
+    public static DependencyField valueOfLowerCase(String fieldKey) {
+        return LOOKUP.get(fieldKey);
+    }
+
+    /**
+     * Set values to the dependency object.
+     *
+     * @param dependency dependency object
+     * @param value      value to be set
+     */
+    public void setValueTo(Dependency dependency, String value) {
+        stringSetter.accept(dependency, value);
+    }
+}

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/fields/ManifestHeader.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/fields/ManifestHeader.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.packerina.toml.model.fields;
+
+import java.util.Locale;
+
+/**
+ * Section headers valid in the manifest toml file.
+ *
+ * @since 0.964
+ */
+public enum ManifestHeader {
+    PACKAGE, DEPENDENCIES, PATCHES, PROXY;
+
+    /**
+     * Check if the section header matches the toml header.
+     *
+     * @param match section header in the toml file
+     * @return if it matches or not
+     */
+    public boolean stringEquals(String match) {
+        return toString().toLowerCase(Locale.ENGLISH).equals(match);
+    }
+}

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/fields/PackageField.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/fields/PackageField.java
@@ -1,0 +1,114 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.packerina.toml.model.fields;
+
+
+import org.ballerinalang.packerina.toml.model.Manifest;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+/**
+ * Fields defined in the manifest "package" header.
+ *
+ * @since 0.964
+ */
+public enum PackageField {
+    NAME(Manifest::setName),
+    VERSION(Manifest::setVersion),
+    DESCRIPTION(Manifest::setDescription),
+    DOCUMENTATION(Manifest::setDocumentationURL),
+    HOMEPAGE(Manifest::setHomepageURL),
+    REPOSITORY(Manifest::setRepositoryURL),
+    README(Manifest::setReadmeFilePath),
+    LICENSE(Manifest::setLicense),
+    AUTHORS(null, Manifest::setAuthors),
+    KEYWORDS(null, Manifest::setKeywords);
+
+    private static final Map<String, PackageField> LOOKUP = new HashMap<>();
+
+    static {
+        for (PackageField packageFieldField : PackageField.values()) {
+            LOOKUP.put(packageFieldField.name().toLowerCase(Locale.ENGLISH), packageFieldField);
+        }
+    }
+
+    private BiConsumer<Manifest, String> stringSetter;
+    private BiConsumer<Manifest, List<String>> listSetter;
+
+    /**
+     * Constructor which sets the string value.
+     *
+     * @param stringSetter value to be set
+     */
+    PackageField(BiConsumer<Manifest, String> stringSetter) {
+        this(stringSetter, null);
+    }
+
+    /**
+     * Constructor which sets a list of strings.
+     *
+     * @param stringSetter string to be set: will be always null
+     * @param listSetter   list of strings
+     */
+    PackageField(BiConsumer<Manifest, String> stringSetter, BiConsumer<Manifest, List<String>> listSetter) {
+        this.stringSetter = stringSetter;
+        this.listSetter = listSetter;
+    }
+
+    /**
+     * Like as valueOf method, but input should be all lower case.
+     *
+     * @param fieldKey Lower case string value of filed to find.
+     * @return Matching enum.
+     */
+    public static PackageField valueOfLowerCase(String fieldKey) {
+        return LOOKUP.get(fieldKey);
+    }
+
+    /**
+     * Set the string value to the manifest object.
+     *
+     * @param manifest manifest object
+     * @param value    string value
+     */
+    public void setStringTo(Manifest manifest, String value) {
+        if (stringSetter != null) {
+            stringSetter.accept(manifest, value);
+        } else {
+            throw new IllegalStateException(this + " field can't have string value " + value);
+        }
+    }
+
+    /**
+     * Set the list of strings to the manifest object.
+     *
+     * @param manifest manifest object
+     * @param list     list of strings
+     */
+    public void setListTo(Manifest manifest, List<String> list) {
+        if (listSetter != null) {
+            listSetter.accept(manifest, list);
+        } else {
+            throw new IllegalStateException(this + " field can't have list value " + list.toString());
+        }
+    }
+}

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/fields/ProxyField.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/fields/ProxyField.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.packerina.toml.model.fields;
+
+
+import org.ballerinalang.packerina.toml.model.Proxy;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+/**
+ * Proxy object fields.
+ *
+ * @since 0.964
+ */
+public enum ProxyField {
+    HOST(Proxy::setHost),
+    PORT(Proxy::setPort),
+    USERNAME(Proxy::setUserName),
+    PASSWORD(Proxy::setPassword);
+
+    private static final Map<String, ProxyField> LOOKUP;
+
+    static {
+        Map<String, ProxyField> lookUpMap = new HashMap<>();
+        for (ProxyField proxyField : ProxyField.values()) {
+            lookUpMap.put(proxyField.name().toLowerCase(Locale.ENGLISH), proxyField);
+        }
+        LOOKUP = lookUpMap;
+    }
+
+    private final BiConsumer<Proxy, String> stringSetter;
+
+    /**
+     * Constructor which sets the string value.
+     *
+     * @param stringSetter string value to be set
+     */
+    ProxyField(BiConsumer<Proxy, String> stringSetter) {
+        this.stringSetter = stringSetter;
+    }
+
+    /**
+     * Like as valueOf method, but input should be all lower case.
+     *
+     * @param fieldKey Lower case string value of filed to find.
+     * @return Matching enum.
+     */
+    public static ProxyField valueOfLowerCase(String fieldKey) {
+        return LOOKUP.get(fieldKey);
+    }
+
+    /**
+     * Set values to the proxy object.
+     *
+     * @param proxy proxy object
+     * @param value value to be set
+     */
+    public void setValueTo(Proxy proxy, String value) {
+        stringSetter.accept(proxy, value);
+    }
+}

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/fields/Section.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/fields/Section.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.packerina.toml.model.fields;
+
+import java.util.Locale;
+
+/**
+ * Section defined in the toml file.
+ *
+ * @since 0.964
+ */
+public enum Section {
+    PACKAGE, DEPENDENCIES, PATCHES, PROXY;
+
+    /**
+     * Check if the section header matches the toml header.
+     *
+     * @param match section header in the toml file
+     * @return if it matches or not
+     */
+    public boolean stringEquals(String match) {
+        return toString().toLowerCase(Locale.ENGLISH).equals(match);
+    }
+}

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/fields/SettingHeaders.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/model/fields/SettingHeaders.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.packerina.toml.model.fields;
+
+import java.util.Locale;
+
+/**
+ * Section headers valid in the settings toml file.
+ *
+ * @since 0.964
+ */
+public enum SettingHeaders {
+    PROXY, CENTRAL;
+
+    /**
+     * Check if the section header matches the toml header.
+     *
+     * @param match section header in the toml file
+     * @return if it matches or not
+     */
+    public boolean stringEquals(String match) {
+        return toString().toLowerCase(Locale.ENGLISH).equals(match);
+    }
+}

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/parser/ManifestBuildListener.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/parser/ManifestBuildListener.java
@@ -1,0 +1,258 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.packerina.toml.parser;
+
+import org.ballerinalang.packerina.toml.model.Dependency;
+import org.ballerinalang.packerina.toml.model.Manifest;
+import org.ballerinalang.packerina.toml.model.fields.DependencyField;
+import org.ballerinalang.packerina.toml.model.fields.ManifestHeader;
+import org.ballerinalang.packerina.toml.model.fields.PackageField;
+import org.ballerinalang.packerina.toml.util.SingletonStack;
+import org.ballerinalang.toml.antlr4.TomlBaseListener;
+import org.ballerinalang.toml.antlr4.TomlParser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Custom listener which is extended from the Toml listener with our own custom logic.
+ *
+ * @since 0.964
+ */
+public class ManifestBuildListener extends TomlBaseListener {
+    private final Manifest manifest;
+    private final SingletonStack<String> currentKey = new SingletonStack<>();
+    private Dependency dependency;
+    private String currentHeader = null;
+
+    /**
+     * Constructor with the manifest object.
+     *
+     * @param manifest manifest object
+     */
+    ManifestBuildListener(Manifest manifest) {
+        this.manifest = manifest;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <p>The default implementation does nothing.</p>
+     *
+     * @param ctx
+     */
+    @Override
+    public void enterKeyVal(TomlParser.KeyValContext ctx) {
+        currentKey.push(ctx.key().getText());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <p>The default implementation does nothing.</p>
+     *
+     * @param ctx
+     */
+    @Override
+    public void enterString(TomlParser.StringContext ctx) {
+        setToManifest(ctx.getText());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <p>The default implementation does nothing.</p>
+     *
+     * @param ctx
+     */
+    @Override
+    public void exitKeyVal(TomlParser.KeyValContext ctx) {
+        setDependencyAndPatches();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <p>The default implementation does nothing.</p>
+     *
+     * @param ctx
+     */
+    @Override
+    public void enterArray(TomlParser.ArrayContext ctx) {
+        setToManifest(ctx.arrayValues());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <p>The default implementation does nothing.</p>
+     *
+     * @param ctx
+     */
+    @Override
+    public void enterStdTable(TomlParser.StdTableContext ctx) {
+        addHeader(ctx.key().getText());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <p>The default implementation does nothing.</p>
+     *
+     * @param ctx
+     */
+    @Override
+    public void enterInlineTable(TomlParser.InlineTableContext ctx) {
+        setToManifest(ctx.inlineTableKeyvals());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <p>The default implementation does ncommentStartSymbol : HASH;
+     * nonEol :  '\r'| '\t';
+     * <p>
+     * comment :  commentStartSymbol wsCommentNewline basicChar* nonEol*;othing.</p>
+     *
+     * @param ctx
+     */
+    @Override
+    public void exitInlineTable(TomlParser.InlineTableContext ctx) {
+        setDependencyAndPatches();
+    }
+
+    /**
+     * Add the dependencies and patches to the manifest object.
+     */
+    private void setDependencyAndPatches() {
+        if (ManifestHeader.DEPENDENCIES.stringEquals(currentHeader)) {
+            this.manifest.addDependency(dependency);
+        } else if (ManifestHeader.PATCHES.stringEquals(currentHeader)) {
+            this.manifest.addPatches(dependency);
+        }
+    }
+
+    /**
+     * Add the key-value pairs specified in the toml file.
+     *
+     * @param value KeyvalContext object
+     */
+    private void setToManifest(String value) {
+        if (currentKey.present() && ManifestHeader.PACKAGE.stringEquals(currentHeader)) {
+            PackageField packageFieldField = PackageField.valueOfLowerCase(currentKey.pop());
+            if (packageFieldField != null) {
+                packageFieldField.setStringTo(this.manifest, value);
+            }
+        } else if (currentKey.present() && (ManifestHeader.DEPENDENCIES.stringEquals(currentHeader) ||
+                ManifestHeader.PATCHES.stringEquals(currentHeader))) {
+            DependencyField dependencyField = DependencyField.valueOfLowerCase(currentKey.pop());
+            if (dependencyField != null) {
+                dependencyField.setValueTo(dependency, value);
+            }
+        }
+    }
+
+    /**
+     * Add array elements to manifest object.
+     *
+     * @param arrayValuesContext ArrayValuesContext object
+     */
+    private void setToManifest(TomlParser.ArrayValuesContext arrayValuesContext) {
+        if (currentKey.present() && ManifestHeader.PACKAGE.stringEquals(currentHeader)) {
+            PackageField packageFieldField = PackageField.valueOfLowerCase(currentKey.pop());
+            if (packageFieldField != null) {
+                List<String> arrayElements = populateList(arrayValuesContext);
+                packageFieldField.setListTo(this.manifest, arrayElements);
+            }
+        }
+    }
+
+    /**
+     * Populate list values.
+     *
+     * @param arrayValuesContext array values
+     * @return list of strings
+     */
+    private List<String> populateList(TomlParser.ArrayValuesContext arrayValuesContext) {
+        List<String> arrayElements = new ArrayList<>();
+        if (arrayValuesContext != null) {
+            for (TomlParser.ArrayvalsNonEmptyContext valueContext : arrayValuesContext.arrayvalsNonEmpty()) {
+                arrayElements.add(valueContext.getText());
+            }
+        }
+        return arrayElements;
+    }
+
+    /**
+     * Add table headers in the toml file.
+     *
+     * @param key key specified in the header
+     */
+    private void addHeader(String key) {
+        currentHeader = key;
+        if (key.split("\\.").length > 1) {
+            currentHeader = key.substring(0, key.indexOf("."));
+            String pkgName = key.substring(key.indexOf(".") + 1);
+            createDependencyObject(pkgName);
+        }
+    }
+
+    /**
+     * Add inline table content specified.
+     *
+     * @param ctx InlineTableKeyvalsContext object
+     */
+    private void setToManifest(TomlParser.InlineTableKeyvalsContext ctx) {
+        if (currentKey.present() &&
+                (ManifestHeader.DEPENDENCIES.stringEquals(currentHeader) ||
+                        ManifestHeader.PATCHES.stringEquals(currentHeader))) {
+            createDependencyObject(String.valueOf(currentKey.pop()));
+            if (ctx != null) {
+                populateDependencyField(ctx);
+            }
+        }
+    }
+
+    /**
+     * Populate dependency fields by iterating over the context object.
+     *
+     * @param ctx Inline table values
+     */
+    private void populateDependencyField(TomlParser.InlineTableKeyvalsContext ctx) {
+        for (TomlParser.InlineTableKeyvalsNonEmptyContext valueContext : ctx.inlineTableKeyvalsNonEmpty()) {
+            String name = valueContext.key().getText();
+            DependencyField dependencyField = DependencyField.valueOfLowerCase(name);
+            if (dependencyField != null) {
+                dependencyField.setValueTo(dependency, valueContext.val().getText());
+            }
+        }
+    }
+
+    /**
+     * Create dependency object and set the name.
+     *
+     * @param packageName pkg name of the dependency
+     */
+    private void createDependencyObject(String packageName) {
+        dependency = new Dependency();
+        DependencyField dependencyField = DependencyField.valueOfLowerCase("name");
+        if (dependencyField != null) {
+            dependencyField.setValueTo(dependency, packageName);
+        }
+    }
+}

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/parser/ManifestProcessor.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/parser/ManifestProcessor.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.packerina.toml.parser;
+
+import org.antlr.v4.runtime.ANTLRFileStream;
+import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.ballerinalang.packerina.toml.model.Manifest;
+import org.ballerinalang.packerina.toml.util.TomlProcessor;
+
+import java.io.IOException;
+
+/**
+ * Manifest Processor which processes the toml file parsed and populate the Manifest POJO.
+ *
+ * @since 0.964
+ */
+public class ManifestProcessor {
+
+    /**
+     * Get the char stream of the content from file.
+     *
+     * @param fileName path of the toml file
+     * @return charstream object
+     * @throws IOException exception if the file cannot be found
+     */
+    public static Manifest parseTomlContentFromFile(String fileName) throws IOException {
+        ANTLRFileStream in = new ANTLRFileStream(fileName);
+        return getManifest(in);
+    }
+
+    /**
+     * Get the char stream from string content.
+     *
+     * @param content toml file content as a string
+     * @return charstream object
+     */
+    public static Manifest parseTomlContentFromString(String content) {
+        ANTLRInputStream in = new ANTLRInputStream(content);
+        return getManifest(in);
+    }
+
+    /**
+     * Get the manifest object by passing the ballerina toml file.
+     *
+     * @param charStream toml file content as a char stream
+     * @return manifest object
+     */
+    private static Manifest getManifest(CharStream charStream) {
+        Manifest manifest = new Manifest();
+        ParseTreeWalker walker = new ParseTreeWalker();
+        walker.walk(new ManifestBuildListener(manifest), TomlProcessor.parseTomlContent(charStream));
+        return manifest;
+    }
+}

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/parser/ProxyBuildListener.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/parser/ProxyBuildListener.java
@@ -1,0 +1,104 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.packerina.toml.parser;
+
+import org.ballerinalang.packerina.toml.model.Proxy;
+import org.ballerinalang.packerina.toml.model.fields.ManifestHeader;
+import org.ballerinalang.packerina.toml.model.fields.ProxyField;
+import org.ballerinalang.packerina.toml.util.SingletonStack;
+import org.ballerinalang.toml.antlr4.TomlBaseListener;
+import org.ballerinalang.toml.antlr4.TomlParser;
+
+/**
+ * Custom listener which is extended from the Toml listener with our own custom logic.
+ *
+ * @since 0.964
+ */
+public class ProxyBuildListener extends TomlBaseListener {
+    private final Proxy proxy;
+    private final SingletonStack<String> currentKey = new SingletonStack<>();
+    private String currentHeader = null;
+
+    /**
+     * Constructor with the proxy object.
+     *
+     * @param proxy proxy object
+     */
+    ProxyBuildListener(Proxy proxy) {
+        this.proxy = proxy;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <p>The default implementation does nothing.</p>
+     *
+     * @param ctx
+     */
+    @Override
+    public void enterKeyVal(TomlParser.KeyValContext ctx) {
+        currentKey.push(ctx.key().getText());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <p>The default implementation does nothing.</p>
+     *
+     * @param ctx
+     */
+    @Override
+    public void enterString(TomlParser.StringContext ctx) {
+        setToProxy(ctx.getText());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <p>The default implementation does nothing.</p>
+     *
+     * @param ctx
+     */
+    @Override
+    public void enterStdTable(TomlParser.StdTableContext ctx) {
+        addHeader(ctx.key().getText());
+    }
+
+    /**
+     * Add table headers in the toml file.
+     *
+     * @param key key specified in the header
+     */
+    private void addHeader(String key) {
+        currentHeader = key;
+    }
+
+    /**
+     * Add the key-value pairs specified in the toml file.
+     *
+     * @param value KeyvalContext object
+     */
+    private void setToProxy(String value) {
+        if (currentKey.present() && ManifestHeader.PROXY.stringEquals(currentHeader)) {
+            ProxyField proxyField = ProxyField.valueOfLowerCase(currentKey.pop());
+            if (proxyField != null) {
+                proxyField.setValueTo(this.proxy, value);
+            }
+        }
+    }
+}

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/parser/SettingsBuildListener.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/parser/SettingsBuildListener.java
@@ -1,0 +1,139 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.packerina.toml.parser;
+
+import org.ballerinalang.packerina.toml.model.Central;
+import org.ballerinalang.packerina.toml.model.Proxy;
+import org.ballerinalang.packerina.toml.model.Settings;
+import org.ballerinalang.packerina.toml.model.fields.CentralField;
+import org.ballerinalang.packerina.toml.model.fields.ProxyField;
+import org.ballerinalang.packerina.toml.model.fields.SettingHeaders;
+import org.ballerinalang.packerina.toml.util.SingletonStack;
+import org.ballerinalang.toml.antlr4.TomlBaseListener;
+import org.ballerinalang.toml.antlr4.TomlParser;
+
+/**
+ * Custom listener which is extended from the Toml listener with our own custom logic.
+ *
+ * @since 0.964
+ */
+public class SettingsBuildListener extends TomlBaseListener {
+    private final Settings settings;
+    private final Proxy proxy = new Proxy();
+    private final Central central = new Central();
+    private final SingletonStack<String> currentKey = new SingletonStack<>();
+    private String currentHeader = null;
+
+    /**
+     * Cosntructor with the settings object.
+     *
+     * @param settings object
+     */
+    SettingsBuildListener(Settings settings) {
+        this.settings = settings;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <p>The default implementation does nothing.</p>
+     *
+     * @param ctx
+     */
+    @Override
+    public void enterKeyVal(TomlParser.KeyValContext ctx) {
+        currentKey.push(ctx.key().getText());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <p>The default implementation does nothing.</p>
+     *
+     * @param ctx
+     */
+    @Override
+    public void enterString(TomlParser.StringContext ctx) {
+        setToManifest(ctx.getText());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <p>The default implementation does nothing.</p>
+     *
+     * @param ctx
+     */
+    @Override
+    public void exitKeyVal(TomlParser.KeyValContext ctx) {
+        setSettingObj();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * <p>The default implementation does nothing.</p>
+     *
+     * @param ctx
+     */
+    @Override
+    public void enterStdTable(TomlParser.StdTableContext ctx) {
+        addHeader(ctx.key().getText());
+    }
+
+    /**
+     * Add the dependencies and patches to the manifest object.
+     */
+    private void setSettingObj() {
+        if (SettingHeaders.CENTRAL.stringEquals(currentHeader)) {
+            this.settings.setCentral(central);
+        } else if (SettingHeaders.PROXY.stringEquals(currentHeader)) {
+            this.settings.setProxy(proxy);
+        }
+    }
+
+    /**
+     * Add the key-value pairs specified in the toml file.
+     *
+     * @param value KeyvalContext object
+     */
+    private void setToManifest(String value) {
+        if (currentKey.present()) {
+            if (SettingHeaders.PROXY.stringEquals(currentHeader)) {
+                ProxyField proxyField = ProxyField.valueOfLowerCase(currentKey.pop());
+                if (proxyField != null) {
+                    proxyField.setValueTo(proxy, value);
+                }
+            } else if (SettingHeaders.CENTRAL.stringEquals(currentHeader)) {
+                CentralField centralField = CentralField.valueOfLowerCase(currentKey.pop());
+                if (centralField != null) {
+                    centralField.setValueTo(central, value);
+                }
+            }
+        }
+    }
+
+    /**
+     * Add table headers in the toml file.
+     *
+     * @param key key specified in the header
+     */
+    private void addHeader(String key) {
+        currentHeader = key;
+    }
+}

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/parser/SettingsProcessor.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/parser/SettingsProcessor.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.packerina.toml.parser;
+
+import org.antlr.v4.runtime.ANTLRFileStream;
+import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.ballerinalang.packerina.toml.model.Settings;
+import org.ballerinalang.packerina.toml.util.TomlProcessor;
+
+import java.io.IOException;
+
+/**
+ * SettingHeaders Processor which processes the settings toml file parsed and populate the SettingHeaders POJO.
+ *
+ * @since 0.964
+ */
+public class SettingsProcessor {
+
+    /**
+     * Get the char stream of the content from file.
+     *
+     * @param fileName path of the toml file
+     * @return charstream object
+     * @throws IOException exception if the file cannot be found
+     */
+    public static Settings parseTomlContentFromFile(String fileName) throws IOException {
+        ANTLRFileStream in = new ANTLRFileStream(fileName);
+        return getSettings(in);
+    }
+
+    /**
+     * Get the char stream from string content.
+     *
+     * @param content toml file content as a string
+     * @return charstream object
+     */
+    public static Settings parseTomlContentFromString(String content) {
+        ANTLRInputStream in = new ANTLRInputStream(content);
+        return getSettings(in);
+    }
+
+    /**
+     * Get the settings config object by passing the settings toml file.
+     *
+     * @param charStream toml file content as a char stream
+     * @return settings object
+     */
+    private static Settings getSettings(CharStream charStream) {
+        Settings settings = new Settings();
+        ParseTreeWalker walker = new ParseTreeWalker();
+        walker.walk(new SettingsBuildListener(settings), TomlProcessor.parseTomlContent(charStream));
+        return settings;
+    }
+}

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/util/SingletonStack.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/util/SingletonStack.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.packerina.toml.util;
+
+/**
+ * This class can be used to handle a singleton content with one element.
+ *
+ * @param <T> Any object
+ * @since 0.964
+ */
+public class SingletonStack<T> {
+    private T content;
+
+    /**
+     * Push object to the content.
+     *
+     * @param obj object to be pushed
+     */
+    public void push(T obj) {
+        if (content != null) {
+            throw new IllegalStateException("Stack is already full");
+        }
+        content = obj;
+    }
+
+    /**
+     * Pops/Gets the object from content.
+     *
+     * @return object if exists, if content is null an exception
+     */
+    public T pop() {
+        if (content == null) {
+            throw new IllegalStateException("Stack is empty");
+        }
+        T lastKey = content;
+        content = null;
+        return lastKey;
+    }
+
+    /**
+     * Check if the object exists in the content.
+     *
+     * @return if object exists true else false
+     */
+    public boolean present() {
+        return content != null;
+    }
+}

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/util/TomlProcessor.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/toml/util/TomlProcessor.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.packerina.toml.util;
+
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.ballerinalang.toml.antlr4.TomlLexer;
+import org.ballerinalang.toml.antlr4.TomlParser;
+
+/**
+ * Util methods for toml processor.
+ *
+ * @since 0.964
+ */
+public class TomlProcessor {
+
+    /**
+     * Generate the proxy object by passing in the toml file.
+     *
+     * @param stream charstream object containing the content
+     * @return proxy object
+     */
+    public static ParseTree parseTomlContent(CharStream stream) {
+        TomlLexer lexer = new TomlLexer(stream);
+
+        // Get a list of matched tokens
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+
+        // Pass the tokens to the parser
+        TomlParser parser = new TomlParser(tokens);
+        return parser.toml();
+    }
+}

--- a/cli/ballerina-packerina/src/test/java/org/ballerinalang/packerina/toml/ManifestProcessorTest.java
+++ b/cli/ballerina-packerina/src/test/java/org/ballerinalang/packerina/toml/ManifestProcessorTest.java
@@ -1,0 +1,261 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.packerina.toml;
+
+
+import org.ballerinalang.packerina.toml.model.Manifest;
+import org.ballerinalang.packerina.toml.parser.ManifestProcessor;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+/**
+ * Test class to populate Manifest object by reading the toml.
+ */
+public class ManifestProcessorTest {
+    @Test(description = "Package name in package section has an effect")
+    public void testPackageName() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[package] \n" +
+                "#Name of the package \n name = \"org-name/string\"");
+        Assert.assertEquals(manifest.getName(), "\"org-name/string\"");
+    }
+
+    @Test(description = "Attribute with single comment doesn't have an effect")
+    public void testAttributeWithSingleComment() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[package] \n" +
+                "#Name of the package \n name = \"org-name/string\"");
+        Assert.assertEquals(manifest.getName(), "\"org-name/string\"");
+    }
+
+    @Test(description = "Attribute with multiline comments doesn't have an effect")
+    public void testAttributeWithMultilineComments() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[package] \n" +
+                "# Name of the package \n #This is the package congif section \n name = \"org-name/string\"");
+        Assert.assertEquals(manifest.getName(), "\"org-name/string\"");
+    }
+
+    @Test(description = "Key with special characters in package section has no effect")
+    public void testPackageNameWithSpecialCharacters() throws IOException {
+        ManifestProcessor.parseTomlContentFromString("[package] \n" +
+                "name-value = \"org-name/string\"");
+        Assert.assertNotEquals(null, "\"org-name/string\"");
+    }
+
+    @Test(description = "Version in package section has an effect")
+    public void testVersion() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[package]\n" +
+                "version = \"v1\"");
+        Assert.assertEquals(manifest.getVersion(), "\"v1\"");
+    }
+
+    @Test(description = "Authors in package section has an effect")
+    public void testAuthors() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[package] \n" +
+                "authors = [\"tyler@wso2.com\", \"manu@wso2.com\"]");
+        Assert.assertEquals(manifest.getAuthors().get(0), "\"tyler@wso2.com\"");
+        Assert.assertEquals(manifest.getAuthors().get(1), "\"manu@wso2.com\"");
+    }
+
+    @Test(description = "Empty author array in package section has an effect")
+    public void testEmptyAuthorArray() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[package] \n" +
+                "authors = []");
+        Assert.assertEquals(manifest.getAuthors().size(), 0);
+    }
+
+    @Test(description = "Description in package section has an effect")
+    public void testDescription() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[package] \n" +
+                "description = \"This is a description about the package\"");
+        Assert.assertEquals(manifest.getDescription(), "\"This is a description about the package\"");
+    }
+
+    @Test(description = "Documentation url in package section has an effect")
+    public void testDocumentationURL() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[package] \n " +
+                "documentation = \"https://ballerinalang.org/docs/api/0.95.5/\"");
+        Assert.assertEquals(manifest.getDocumentationURL(), "\"https://ballerinalang.org/docs/api/0.95.5/\"");
+    }
+
+    @Test(description = "Homepage url in package section has an effect")
+    public void testHomePageURL() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[package] \n " +
+                "homepage = \"https://ballerinalang.org/\"");
+        Assert.assertEquals(manifest.getHomepageURL(), "\"https://ballerinalang.org/\"");
+    }
+
+    @Test(description = "Repository url in package section has an effect")
+    public void testRepositoryURL() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[package] \n " +
+                "repository = \"https://github.com/ballerinalang/ballerina\"");
+        Assert.assertEquals(manifest.getRepositoryURL(), "\"https://github.com/ballerinalang/ballerina\"");
+    }
+
+    @Test(description = "Version in non-package section has no effect")
+    public void testVersionNeg() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[patch] \n version = \"v1\"");
+        Assert.assertNotEquals(manifest.getVersion(), "\"v1\"");
+    }
+
+    @Test(description = "Location in package section has no effect")
+    public void testLocationNeg() throws IOException {
+        ManifestProcessor.parseTomlContentFromString("[package] \n location = \"local\"");
+        Assert.assertNotEquals(null, "\"local\"");
+    }
+
+    @Test(description = "Readme file path in package section has an effect")
+    public void testReadmeFilePath() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[package] \n " +
+                "readme = \"https://github.com/ballerinalang/composer/blob/master/README.md\"");
+        Assert.assertEquals(manifest.getReadmeFilePath(), "\"https://github.com/ballerinalang/composer/blob" +
+                "/master/README.md\"");
+    }
+
+    @Test(description = "Keywords in package section has an effect")
+    public void testKeywords() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[package] \n" +
+                "keywords=[\"ballerina\",\"security\",\"security\"]");
+        Assert.assertEquals(manifest.getKeywords().get(0), "\"ballerina\"");
+        Assert.assertEquals(manifest.getKeywords().get(1), "\"security\"");
+        Assert.assertEquals(manifest.getKeywords().size(), 3);
+    }
+
+    @Test(description = "Description in package section has an effect")
+    public void testLicenseDescription() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[package] \n " +
+                "license = \"MIT OR Apache-2.0\"");
+        Assert.assertEquals(manifest.getLicense(), "\"MIT OR Apache-2.0\"");
+    }
+
+    @Test(description = "One dependency added to the dependencies section has an effect")
+    public void testSingleDependancies() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[dependencies] \n " +
+                "string-utils = {location = \"src/string-utils\", version = \"0.15\"} \n");
+        Assert.assertEquals(manifest.getDependencies().get(0).getPackageName(), "string-utils");
+        Assert.assertEquals(manifest.getDependencies().get(0).getVersion(), "\"0.15\"");
+        Assert.assertEquals(manifest.getDependencies().get(0).getLocation(), "\"src/string-utils\"");
+    }
+
+    @Test(description = "Empty dependency added to the dependencies section has no effect")
+    public void testSingleEmptyDependancies() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[dependencies] \n " +
+                "string-utils = {} \n");
+        Assert.assertEquals(manifest.getDependencies().get(0).getPackageName(), "string-utils");
+    }
+
+    @Test(description = "Multiple dependencies added to the dependencies section has an effect")
+    public void testMultipleDependancies() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[dependencies] \n " +
+                "string-utils = {location = \"src/string-utils\", version = \"0.15\" } \n " +
+                "jquery = { version = \"2.23\" } \n");
+        Assert.assertEquals(manifest.getDependencies().get(0).getPackageName(), "string-utils");
+        Assert.assertEquals(manifest.getDependencies().get(0).getVersion(), "\"0.15\"");
+        Assert.assertEquals(manifest.getDependencies().get(1).getPackageName(), "jquery");
+        Assert.assertEquals(manifest.getDependencies().get(1).getVersion(), "\"2.23\"");
+    }
+
+    @Test(description = "One dependency added to the dependencies section individually has an effect")
+    public void testSingleDependanciesAdded() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[dependencies.string-utils] \n " +
+                "version = \"0.15\" \n location = \"src/string-utils\"");
+        Assert.assertEquals(manifest.getDependencies().get(0).getPackageName(), "string-utils");
+        Assert.assertEquals(manifest.getDependencies().get(0).getVersion(), "\"0.15\"");
+        Assert.assertEquals(manifest.getDependencies().get(0).getLocation(), "\"src/string-utils\"");
+    }
+
+    @Test(description = "Multiple dependencies added to the dependencies section individually has an effect")
+    public void testMultipleDependanciesAddedIndividually() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[dependencies.string-utils] \n " +
+                "version = \"0.15\" \n location = \"src/string-utils\" \n [dependencies.jquery] \n " +
+                "version = \"2.23\"");
+
+        Assert.assertEquals(manifest.getDependencies().get(0).getPackageName(), "string-utils");
+        Assert.assertEquals(manifest.getDependencies().get(0).getVersion(), "\"0.15\"");
+        Assert.assertEquals(manifest.getDependencies().get(0).getLocation(), "\"src/string-utils\"");
+
+        Assert.assertEquals(manifest.getDependencies().get(1).getPackageName(), "jquery");
+        Assert.assertEquals(manifest.getDependencies().get(1).getVersion(), "\"2.23\"");
+        Assert.assertEquals(manifest.getDependencies().get(1).getLocation(), null);
+    }
+
+    @Test(description = "One patch added to the patches section has an effect")
+    public void testSinglePatch() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[patches] \n " +
+                "string-utils = {version = \"0.16.1\", location = \"src/patches/string-utils\" } \n");
+        Assert.assertEquals(manifest.getPatches().get(0).getPackageName(), "string-utils");
+        Assert.assertEquals(manifest.getPatches().get(0).getVersion(), "\"0.16.1\"");
+        Assert.assertEquals(manifest.getPatches().get(0).getLocation(), "\"src/patches/string-utils\"");
+    }
+
+    @Test(description = "Multiple patches added to the patches section has an effect")
+    public void testMultiplePatches() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[patches] \n " +
+                "string-utils = {version = \"0.15.2\" } \n " +
+                "jquery = { version = \"2.23.1\" } \n");
+        Assert.assertEquals(manifest.getPatches().get(0).getPackageName(), "string-utils");
+        Assert.assertEquals(manifest.getPatches().get(0).getVersion(), "\"0.15.2\"");
+        Assert.assertEquals(manifest.getPatches().get(1).getPackageName(), "jquery");
+        Assert.assertEquals(manifest.getPatches().get(1).getVersion(), "\"2.23.1\"");
+    }
+
+    @Test(description = "Dependencies added both ways i.e. individually and multiple dependencies together has" +
+            "an effect")
+    public void testMixtureOfDependencies() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[dependencies.string-utils] \n " +
+                "version = \"0.15\" \n location = \"src/string-utils\" \n [dependencies] \n " +
+                "jquery = {version = \"2.23\"} \n react = {version = \"1.66\", location = \"npm-modules/react\"} \n" +
+                "[dependencies.toml] \n version = \"0.4.5\" \n ");
+
+        Assert.assertEquals(manifest.getDependencies().size(), 4);
+        Assert.assertEquals(manifest.getDependencies().get(0).getPackageName(), "string-utils");
+        Assert.assertEquals(manifest.getDependencies().get(0).getVersion(), "\"0.15\"");
+        Assert.assertEquals(manifest.getDependencies().get(0).getLocation(), "\"src/string-utils\"");
+
+        Assert.assertEquals(manifest.getDependencies().get(1).getPackageName(), "jquery");
+        Assert.assertEquals(manifest.getDependencies().get(1).getVersion(), "\"2.23\"");
+        Assert.assertEquals(manifest.getDependencies().get(1).getLocation(), null);
+
+        Assert.assertEquals(manifest.getDependencies().get(2).getPackageName(), "react");
+        Assert.assertEquals(manifest.getDependencies().get(2).getVersion(), "\"1.66\"");
+        Assert.assertEquals(manifest.getDependencies().get(2).getLocation(), "\"npm-modules/react\"");
+
+        Assert.assertEquals(manifest.getDependencies().get(3).getPackageName(), "toml");
+        Assert.assertEquals(manifest.getDependencies().get(3).getVersion(), "\"0.4.5\"");
+    }
+
+    @Test(description = "Dependencies and patches added together has an effect")
+    public void testDependenciesAndPatches() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromString("[dependencies.string-utils] \n " +
+                "version = \"0.15\" \n location = \"src/string-utils\" \n [patches] \n jobapi = {version = \"2.23\"} " +
+                "\n [dependencies] \n jquery = {version = \"2.23\"} \n react = {version = \"1.66\", " +
+                "location = \"npm-modules/react\"} \n [patches.toml] \n version = \"0.4.5\" \n");
+
+        Assert.assertEquals(manifest.getDependencies().size(), 3);
+        Assert.assertEquals(manifest.getPatches().size(), 2);
+
+        Assert.assertEquals(manifest.getDependencies().get(0).getPackageName(), "string-utils");
+        Assert.assertEquals(manifest.getDependencies().get(0).getVersion(), "\"0.15\"");
+        Assert.assertEquals(manifest.getDependencies().get(1).getPackageName(), "jquery");
+        Assert.assertEquals(manifest.getDependencies().get(2).getVersion(), "\"1.66\"");
+
+        Assert.assertEquals(manifest.getPatches().get(0).getPackageName(), "jobapi");
+        Assert.assertEquals(manifest.getPatches().get(1).getPackageName(), "toml");
+
+    }
+}

--- a/cli/ballerina-packerina/src/test/java/org/ballerinalang/packerina/toml/SingletonStackTest.java
+++ b/cli/ballerina-packerina/src/test/java/org/ballerinalang/packerina/toml/SingletonStackTest.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.packerina.toml;
+
+import org.ballerinalang.packerina.toml.util.SingletonStack;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Class to test the singleton stack used to handle the keys (properties) in the toml file.
+ */
+public class SingletonStackTest {
+    @Test(description = "The value in the stack should be retrieved/popped out if a value is present")
+    public void testPopWithValue() {
+        SingletonStack singletonStackTest = new SingletonStack();
+        singletonStackTest.push("hello");
+        Assert.assertEquals(singletonStackTest.pop(), "hello");
+    }
+
+    @Test(description = "The value should be returned as null if its not instantiated")
+    public void testPopWithoutInstaniating() {
+        SingletonStack singletonStackTest = null;
+        Assert.assertEquals(singletonStackTest, null);
+    }
+
+    @Test(description = "The value should not be pushed to the stack if the stack already contains a value it should " +
+            "give an exception", expectedExceptions = IllegalStateException.class)
+    public void testPopWithoutValue() {
+        SingletonStack singletonStackTest = new SingletonStack();
+        singletonStackTest.pop();
+        Assert.assertEquals(singletonStackTest.present(), true);
+    }
+
+    @Test(description = "Return true if the value exists")
+    public void testWithValuePresent() {
+        SingletonStack singletonStackTest = new SingletonStack();
+        singletonStackTest.push("hello");
+        Assert.assertEquals(singletonStackTest.present(), true);
+    }
+
+    @Test(description = "Return false if a value does not exists")
+    public void testWithValueAbsent() {
+        SingletonStack singletonStackTest = new SingletonStack();
+        Assert.assertEquals(singletonStackTest.present(), false);
+    }
+
+    @Test(description = "The value should be pushed to the stack if the stack is not null")
+    public void testPushToStackWithValue() {
+        SingletonStack singletonStackTest = new SingletonStack();
+        singletonStackTest.push("hello");
+        Assert.assertEquals(singletonStackTest.present(), true);
+        Assert.assertEquals(singletonStackTest.pop(), "hello");
+    }
+
+    @Test(description = "The value should not be pushed to the stack if the stack already contains a value it should " +
+            "give an exception", expectedExceptions = IllegalStateException.class)
+    public void testPushMultipleValuesToStack() {
+        SingletonStack singletonStackTest = new SingletonStack();
+        singletonStackTest.push("hello");
+        singletonStackTest.push("world");
+        Assert.assertEquals(singletonStackTest.present(), true);
+    }
+}

--- a/cli/ballerina-packerina/src/test/java/org/ballerinalang/packerina/toml/TomlFileToManifestTest.java
+++ b/cli/ballerina-packerina/src/test/java/org/ballerinalang/packerina/toml/TomlFileToManifestTest.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.packerina.toml;
+
+import org.ballerinalang.packerina.toml.model.Manifest;
+import org.ballerinalang.packerina.toml.parser.ManifestProcessor;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+/**
+ * Test class to populate a Manifest object from a toml file.
+ */
+public class TomlFileToManifestTest {
+    private static final String userDir = System.getProperty("user.dir");
+    private static final String resource_dir = userDir + "/src/test/resources/";
+
+    @Test(description = "Test which covers all the attributes tested above")
+    public void testTomlFile() throws IOException {
+        Manifest manifest = ManifestProcessor.parseTomlContentFromFile(resource_dir + "example.toml");
+        Assert.assertEquals(manifest.getName(), "\"org-name/string\"");
+        Assert.assertEquals(manifest.getVersion(), "\"1.0.0\"");
+        Assert.assertEquals(manifest.getDescription(), "\"This is a sample description which contains information\"");
+        Assert.assertEquals(manifest.getDocumentationURL(), "\"https://ballerinalang.org/docs/api/0.95.5/\"");
+        Assert.assertEquals(manifest.getHomepageURL(), "\"https://ballerinalang.org/\"");
+        Assert.assertEquals(manifest.getRepositoryURL(), "\"https://github.com/ballerinalang/ballerina\"");
+        Assert.assertEquals(manifest.getReadmeFilePath(), "\"https://github.com/ballerinalang/composer/blob/" +
+                "master/README.md\"");
+        Assert.assertEquals(manifest.getAuthors().get(0), "\"tyler@wso2.com\"");
+        Assert.assertEquals(manifest.getAuthors().get(1), "\"manu@wso2.com\"");
+
+        Assert.assertEquals(manifest.getKeywords().get(0), "\"ballerina\"");
+        Assert.assertEquals(manifest.getKeywords().get(2), "\"crypto\"");
+        Assert.assertEquals(manifest.getKeywords().size(), 3);
+
+        Assert.assertEquals(manifest.getDependencies().size(), 6);
+        Assert.assertEquals(manifest.getDependencies().get(0).getPackageName(), "synchapi");
+        Assert.assertEquals(manifest.getDependencies().get(0).getVersion(), "\"0.9.2\"");
+
+        Assert.assertEquals(manifest.getDependencies().get(1).getLocation(), "\"src/libc\"");
+        Assert.assertEquals(manifest.getDependencies().get(1).getPackageName(), "libc");
+
+        Assert.assertEquals(manifest.getDependencies().get(2).getPackageName(), "string-utils");
+        Assert.assertEquals(manifest.getDependencies().get(3).getLocation(), null);
+
+        Assert.assertEquals(manifest.getDependencies().get(4).getPackageName(), "toml");
+        Assert.assertEquals(manifest.getDependencies().get(4).getVersion(), "\"0.4.6\"");
+
+        Assert.assertEquals(manifest.getDependencies().get(5).getLocation(), "\"src/core/jobapi\"");
+        Assert.assertEquals(manifest.getDependencies().get(5).getPackageName(), "jobapi.core");
+    }
+}

--- a/cli/ballerina-packerina/src/test/resources/example.toml
+++ b/cli/ballerina-packerina/src/test/resources/example.toml
@@ -1,0 +1,53 @@
+[package]
+# Name of the package
+name = "org-name/string"
+
+#The current version, obeying semver
+version = "1.0.0"
+
+authors = ["tyler@wso2.com","manu@wso2.com"]
+
+# A short blurb about the package. This is not rendered in any format when
+# uploaded to central.ballerina.io (aka this is not markdown).
+description = "This is a sample description which contains information"
+
+# These URLs point to more information about the package. These are
+# intended to be webviews of the relevant data, not necessarily compatible
+# with VCS tools and the like i.e. nan or inf.
+documentation = "https://ballerinalang.org/docs/api/0.95.5/"
+homepage = "https://ballerinalang.org/"
+repository = "https://github.com/ballerinalang/ballerina"
+
+# This points to a file under the package root (relative to this `Cargo.toml`).
+# The contents of this file are stored and indexed in the registry.
+# central.ballerina.io will render this file and place the result on the packages.
+readme = "https://github.com/ballerinalang/composer/blob/master/README.md"
+
+# This is a list of up to five keywords that describe this ballerina package. Keywords
+# are searchable on Ballerina Central, and you may choose any words that would
+# help someone find this ballerina package.
+keywords = ["ballerina", "security", "crypto"]
+
+# This is a string description of the license for this package. Currently
+# string-utils will validate the license provided against a whitelist of known
+# license identifiers from http://spdx.org/licenses/. Multiple licenses can be
+# separated with a `/`.
+license = "MIT OR Apache-2.0"
+
+# Dependencies are searched in local repository and then Ballerina Central.
+# <package-name> is fully qualified package name with org name.
+# The <package-name> in the table specifier must be fully qualified.
+[dependencies.synchapi]
+version = "0.9.2"
+location = "src/synchapi"
+
+# Dependency list are searched in local repository and then Ballerina Central.
+[dependencies]
+libc = {location = "src/libc", version = "0.4.6"}
+string-utils = { location = "src/string-utils", version = "0.15" }
+curl = {version = "0.4.6"}
+toml = {version = "0.4.6"}
+
+[dependencies.jobapi.core]
+version = "1.1"
+location = "src/core/jobapi"

--- a/cli/ballerina-packerina/src/test/resources/testng.xml
+++ b/cli/ballerina-packerina/src/test/resources/testng.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+
+WSO2 Inc. licenses this file to you under the Apache License,
+Version 2.0 (the "License"); you may not use this file except
+in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="ballerina-toml-parser-test-suite">
+    <test name="ballerina-toml-parser-test-suite" preserve-order="true" parallel="false">
+        <packages>
+            <package name="org.ballerinalang.toml.parser"/>
+        </packages>
+    </test>
+</suite>


### PR DESCRIPTION
## Purpose
> This PR adds the custom listeners which are implemented by extending the TomlBaseListener to retrieve the manifest POJO object
